### PR TITLE
create vscode development container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,85 @@
+FROM ubuntu:18.04
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Uncomment the following COPY line and the corresponding lines in the `RUN` command if you wish to
+# include your requirements in the image itself. It is suggested that you only do this if your
+# requirements rarely (if ever) change.
+# COPY requirements.txt /tmp/pip-tmp/
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git openssh-client less iproute2 procps lsb-release \
+    #
+    # Update Python environment based on requirements.txt
+    # && pip --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    # && rm -rf /tmp/pip-tmp \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Let the installed vscode extensions persist between rebuilds
+# See: https://code.visualstudio.com/docs/remote/containers-advanced#_avoiding-extension-reinstalls-on-container-rebuild
+RUN mkdir -p /home/$USERNAME/.vscode-server/extensions && chown -R $USERNAME /home/$USERNAME/.vscode-server
+
+RUN apt-get update && apt-get install -y nano
+
+RUN apt-get install -y software-properties-common
+
+#########################################
+# Install gfortran-9
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN apt-get update && apt-get install -y gfortran-9 gfortran-7
+
+#########################################
+# Install g++
+RUN apt-get update && apt-get install -y g++
+
+#########################################
+# Install Julia
+RUN apt-get install -y wget
+RUN wget -qO- https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.2.0-linux-x86_64.tar.gz | tar -xzv
+ENV PATH="/julia-1.2.0/bin:${PATH}"
+USER vscode
+RUN julia -e 'import Pkg; Pkg.add("BenchmarkTools")'
+USER root
+
+#########################################
+### Install Python                                                               
+RUN apt-get update && apt-get -y install git wget build-essential
+RUN apt-get install -y python3 python3-pip
+### Make sure we have python3 and a working locale
+RUN (rm /usr/bin/python || true) && ln -s python3 /usr/bin/python && (rm /usr/bin/pip || true) && ln -s pip3 /usr/bin/pip
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+RUN apt-get install -y locales && locale-gen en_US.UTF-8
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3-tk
+# numpy and numba
+RUN pip install numpy numba
+
+#########################################
+# Install octave
+RUN apt-get update && apt-get -y install octave
+
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+// See https://aka.ms/vscode-remote/containers for the
+// documentation about the devcontainer.json format
+{
+	"name": "Latex in Ubuntu 18.04",
+	"context": "..",
+	"dockerFile": "Dockerfile",
+	"extensions": [
+        "eamodio.gitlens"
+	],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": ".devcontainer/post_create.sh",
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+cat <<EOT >> ~/.bashrc
+alias gs="git status"
+alias gpl="git pull"
+alias gps="git push"
+alias gpst="git push && git push --tags"
+alias gc="git commit"
+alias ga="git add -u"
+EOT
+

--- a/.devcontainer/tasks/run_arraysinglethread_tests.sh
+++ b/.devcontainer/tasks/run_arraysinglethread_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+cd /workspaces/floatingspeed/arraysinglethread
+
+./do_complextimings.sh

--- a/.devcontainer/tasks/run_lap3dkernel_tests.sh
+++ b/.devcontainer/tasks/run_lap3dkernel_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+cd /workspaces/floatingspeed/lap3dkernel
+
+./run_all_tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+a.out
+*.o
+complexmulttimingf
+complexmulttimingc
+complexmulttimingcpp

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    // The "bash -ic" is needed here so that our ~/.bashrc gets sourced. See: https://github.com/microsoft/vscode/issues/29412
+    "version": "2.0.0",
+    "tasks": [
+        {
+            // Run all tests
+            "label": "Run lap3dkernel tests",
+            "type": "shell",
+            "command": "cd .devcontainer/tasks && bash -ic ./run_lap3dkernel_tests.sh"
+        },
+        {
+            // Run all tests
+            "label": "Run arraysinglethread tests",
+            "type": "shell",
+            "command": "cd .devcontainer/tasks && bash -ic ./run_arraysinglethread_tests.sh"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -8,3 +8,42 @@ Alex Barnett 2016--2020
 
 * ``arraysinglethread``: compare C/C++/Fortran speeds for complex and real double-precision arithmetic, on a 1D array.
 * ``lap3dkernel``: compare various languages speed in a multithreaded implementation of direct summation of the 1/r kernel.
+
+## Open in a containerized development environment using vscode
+
+You can use [Visual Studio Code](https://code.visualstudio.com/) to open a containerized development environment. This creates a Docker container with all of the compilers and tools pre-installed, including Fortran, Python, Octave, g++, and Julia. You can then run the tests and seamlessly edit the code all within this environment, and the source files are automatically sync'd with the host environment.
+
+Note: MATLAB is not installed within the development container.
+
+### Prerequisites
+
+* [Docker](https://docs.docker.com/install/)
+* [Visual Studio Code](https://code.visualstudio.com/)
+
+### Instructions
+
+```bash
+# Clone this repo
+git clone [repo-url] floatingspeed
+cd floatingspeed
+
+# Open in Visual Studio Code
+code .
+```
+
+Install the [Remote-Containers vscode extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) (if not already installed)
+
+In the lower-left corner of the vscode window you should see a little green icon. Click that and select "Reopen in Container"
+
+Now the container will be built on your system (may take several minutes). And then your project will appear -- inside the development environment container.
+
+If you are curious, the Docker recipe for installing all the compilers can be found at [.devcontainer/Dockerfile](.devcontainer/Dockerfile)
+
+You can now either run the tests from the built-in vscode terminal, or you can run them using the built-in tasks for this project.
+
+To run a task, launch the vscode command menu (Ctrl+Shift+P) and search for "Run Task" and press enter. Then select one of the two tasks that appear (e.g., "Run arraysinglethread test") and press enter. Then enter again to continue. A new vscode terminal will open and run your test.
+
+If you are curious, the tasks are configured at [.vscode/tasks.json](.vscode/tasks.json).
+
+
+


### PR DESCRIPTION
This PR adds a .devcontainer/ folder with a full Docker recipe for installing all the development tools needed for these tests (excluding MATLAB). This then enables automatic building and opening the isolated development environment inside vscode. I have added instructions for doing this in the README. The only prerequisites are docker and vscode as the fortran, julia, octave, python, and g++ are all installed within the dev container.