### PR TITLE
add fast rsqrt comparison in c++

### DIFF
--- a/lap3dkernel/c++SIMD/VCL_AgnerFog_version1/vectorf256.h
+++ b/lap3dkernel/c++SIMD/VCL_AgnerFog_version1/vectorf256.h
@@ -1785,6 +1785,10 @@ static inline Vec4d sqrt(Vec4d const & a) {
     return _mm256_sqrt_pd(a);
 }
 
+static inline Vec4d approx_rsqrt(Vec4d const & a) {
+    return _mm256_cvtps_pd(_mm_rsqrt_ps(_mm256_cvtpd_ps(a)));
+}
+
 // function square: a * a
 static inline Vec4d square(Vec4d const & a) {
     return a * a;

--- a/lap3dkernel/c++SIMD/VCL_AgnerFog_version1/vectorf256.h
+++ b/lap3dkernel/c++SIMD/VCL_AgnerFog_version1/vectorf256.h
@@ -1785,6 +1785,7 @@ static inline Vec4d sqrt(Vec4d const & a) {
     return _mm256_sqrt_pd(a);
 }
 
+// aprrox 1/sqrt(a) function, takes double type as function argument
 static inline Vec4d approx_rsqrt(Vec4d const & a) {
     return _mm256_cvtps_pd(_mm_rsqrt_ps(_mm256_cvtpd_ps(a)));
 }

--- a/lap3dkernel/c++SIMD/VCL_AgnerFog_version1/vectorf512.h
+++ b/lap3dkernel/c++SIMD/VCL_AgnerFog_version1/vectorf512.h
@@ -1379,6 +1379,10 @@ static inline Vec8d sqrt(Vec8d const & a) {
     return _mm512_sqrt_pd(a);
 }
 
+static inline Vec8d approx_rsqrt(Vec8d const & a) {
+    return _mm512_cvtps_pd(_mm256_rsqrt_ps(_mm512_cvtpd_ps(a)));
+}
+
 // function square: a * a
 static inline Vec8d square(Vec8d const & a) {
     return a * a;

--- a/lap3dkernel/c++SIMD/VCL_AgnerFog_version1/vectorf512.h
+++ b/lap3dkernel/c++SIMD/VCL_AgnerFog_version1/vectorf512.h
@@ -1379,6 +1379,7 @@ static inline Vec8d sqrt(Vec8d const & a) {
     return _mm512_sqrt_pd(a);
 }
 
+// aprrox 1/sqrt(a) function, takes double type as function argument
 static inline Vec8d approx_rsqrt(Vec8d const & a) {
     return _mm512_cvtps_pd(_mm256_rsqrt_ps(_mm512_cvtpd_ps(a)));
 }

--- a/lap3dkernel/c++SIMD/VCL_AgnerFog_version1/vectorf512e.h
+++ b/lap3dkernel/c++SIMD/VCL_AgnerFog_version1/vectorf512e.h
@@ -1346,6 +1346,7 @@ static inline Vec8d sqrt(Vec8d const & a) {
     return Vec8d(sqrt(a.get_low()), sqrt(a.get_high()));
 }
 
+// aprrox 1/sqrt(a) function, takes double type as function argument
 static inline Vec8d approx_rsqrt(Vec8d const & a) {
     return Vec8d(approx_rsqrt(a.get_low()), approx_rsqrt(a.get_high()));
 }

--- a/lap3dkernel/c++SIMD/VCL_AgnerFog_version1/vectorf512e.h
+++ b/lap3dkernel/c++SIMD/VCL_AgnerFog_version1/vectorf512e.h
@@ -1346,6 +1346,10 @@ static inline Vec8d sqrt(Vec8d const & a) {
     return Vec8d(sqrt(a.get_low()), sqrt(a.get_high()));
 }
 
+static inline Vec8d approx_rsqrt(Vec8d const & a) {
+    return Vec8d(approx_rsqrt(a.get_low()), approx_rsqrt(a.get_high()));
+}
+
 // function square: a * a
 static inline Vec8d square(Vec8d const & a) {
     return a * a;

--- a/lap3dkernel/c++SIMD/lap3dkernel.cpp
+++ b/lap3dkernel/c++SIMD/lap3dkernel.cpp
@@ -25,6 +25,15 @@
 
 // choose double prec throughout
 typedef double Real;
+typedef long Integer;
+
+template <Integer e, class Real> static inline constexpr Real pow_helper(Real b) {
+  return (e > 0) ? ((e & 1) ? b : Real(1)) * pow_helper<(e>>1),Real>(b*b) : Real(1);
+}
+
+template <Integer e, class Real> inline constexpr Real pow(Real b) {
+  return (e > 0) ? pow_helper<e,Real>(b) : 1/pow_helper<-e,Real>(b);
+}
 
 void test_kernel_ts(const Real* Xs, const Real* Ys, const Real* Zs,
                     int ns, const Real* charge,  
@@ -101,6 +110,38 @@ void test_kernel_vec512(const Real* Xs, const Real* Ys, const Real* Zs,
     }
 }
 
+void test_kernel_vec512_fast_rsqrt(const Real* Xs, const Real* Ys, const Real* Zs,
+                    int ns, const Real* charge,  
+                 const Real* Xt, const Real* Yt, const Real* Zt, int nt, Real* pot){
+#pragma omp parallel for
+    for(int t = 0; t < nt; t += 8){
+
+      Vec8d Xt_vec, Yt_vec, Zt_vec, pot_vec;
+        // load
+        Xt_vec.load(Xt + t);
+        Yt_vec.load(Yt + t);
+        Zt_vec.load(Zt + t);
+        pot_vec.load(pot + t);
+        
+        for(int s = 0; s < ns; s++){
+            Vec8d dx = Vec8d(Xs[s]) - Xt_vec;
+            Vec8d dy = Vec8d(Ys[s]) - Yt_vec;
+            Vec8d dz = Vec8d(Zs[s]) - Zt_vec;
+            Vec8d r2 = dx*dx+dy*dy+dz*dz;
+            
+            // Newton iterations for rsqrt double precision
+            Vec8d rinv = approx_rsqrt(r2);
+            rinv *= ((3.0) - r2 * rinv * rinv);
+            rinv *= ((3.0 * pow<pow<0>(3)*3-1>(2.0)) - r2 * rinv * rinv) * (pow<(pow<0>(3)*3-1)*3/2+1>(0.5));
+
+            pot_vec += Vec8d(charge[s]) * rinv;
+        }
+
+        // store
+        pot_vec.store(pot + t);
+    }
+}
+
 void test_kernel_vec256(const Real* Xs, const Real* Ys, const Real* Zs,
                     int ns, const Real* charge,  
                  const Real* Xt, const Real* Yt, const Real* Zt, int nt, Real* pot){
@@ -120,6 +161,38 @@ void test_kernel_vec256(const Real* Xs, const Real* Ys, const Real* Zs,
             Vec4d dz = Vec4d(Zs[s]) - Zt_vec;
             Vec4d r2 = dx*dx+dy*dy+dz*dz;
             pot_vec += Vec4d(charge[s]) / sqrt(r2);
+        }
+
+        // store
+        pot_vec.store(pot + t);
+    }
+}
+
+void test_kernel_vec256_fast_rsqrt(const Real* Xs, const Real* Ys, const Real* Zs,
+                    int ns, const Real* charge,  
+                 const Real* Xt, const Real* Yt, const Real* Zt, int nt, Real* pot){
+#pragma omp parallel for
+    for(int t = 0; t < nt; t += 4){
+
+      Vec4d Xt_vec, Yt_vec, Zt_vec, pot_vec;
+        // load
+        Xt_vec.load(Xt + t);
+        Yt_vec.load(Yt + t);
+        Zt_vec.load(Zt + t);
+        pot_vec.load(pot + t);
+        
+        for(int s = 0; s < ns; s++){
+            Vec4d dx = Vec4d(Xs[s]) - Xt_vec;
+            Vec4d dy = Vec4d(Ys[s]) - Yt_vec;
+            Vec4d dz = Vec4d(Zs[s]) - Zt_vec;
+            Vec4d r2 = dx*dx+dy*dy+dz*dz;
+            
+            // Newton iterations for rsqrt double precision
+            Vec4d rinv = approx_rsqrt(r2);
+            rinv *= ((3.0) - r2 * rinv * rinv);
+            rinv *= ((3.0 * pow<pow<0>(3)*3-1>(2.0)) - r2 * rinv * rinv) * (pow<(pow<0>(3)*3-1)*3/2+1>(0.5));
+
+            pot_vec += Vec4d(charge[s]) * rinv;
         }
 
         // store
@@ -155,8 +228,23 @@ int main (void)
   Real t = omp_get_wtime()-ts;
   Real ans = 0;
   for(auto& x : pot) ans+=x;    // this answer checks it agrees btw methods, to 15 digits
-  std::cout << std::setprecision(15);
+  std::cout << std::setprecision(16);
   std::cout<<"N="<<ns<<", M="<<nt<<". manual VCL SIMD avx512, ans: "<<ans<<"\n";
+  std::cout << std::setprecision(3);
+  std::cout<<"\t\t\t\ttime: "<<t<<" s      \t"<<ntest*ns*nt/t/1e9<<" Gpair/sec\n";
+
+  // kernel run vec 8d  ... only useful if have AVX512, fast rsqrt
+  for (auto& x : pot) x = 0.0;            // needed since funcs add to pot
+  ts = omp_get_wtime();
+  for(int i=0; i<ntest; i++) {
+    test_kernel_vec512_fast_rsqrt(&Xs[0], &Ys[0], &Zs[0], ns, &charge[0], 
+                   &Xt[0], &Yt[0], &Zt[0], nt, &pot[0]);
+  }
+  t = omp_get_wtime()-ts;
+  ans = 0;
+  for(auto& x : pot) ans+=x;    // this answer checks it agrees btw methods, to 15 digits
+  std::cout << std::setprecision(16);
+  std::cout<<"N="<<ns<<", M="<<nt<<". manual VCL SIMD avx512 fast rsqrt, ans: "<<ans<<"\n";
   std::cout << std::setprecision(3);
   std::cout<<"\t\t\t\ttime: "<<t<<" s      \t"<<ntest*ns*nt/t/1e9<<" Gpair/sec\n";
 
@@ -170,8 +258,23 @@ int main (void)
   t = omp_get_wtime()-ts;
   ans = 0;
   for(auto& x : pot) ans+=x;
-  std::cout << std::setprecision(15);
+  std::cout << std::setprecision(16);
   std::cout<<"N="<<ns<<", M="<<nt<<". manual VCL SIMD avx2 (256), ans: "<<ans<<"\n";
+  std::cout << std::setprecision(3);
+  std::cout<<"\t\t\t\ttime: "<<t<<" s      \t"<<ntest*ns*nt/t/1e9<<" Gpair/sec\n";
+
+  // kernel run vec 4d   ... tests avx2, fast rsqrt
+  for (auto& x : pot) x = 0.0;
+  ts = omp_get_wtime();
+  for(int i=0; i<ntest; i++) {
+    test_kernel_vec256_fast_rsqrt(&Xs[0], &Ys[0], &Zs[0], ns, &charge[0], 
+                   &Xt[0], &Yt[0], &Zt[0], nt, &pot[0]);
+  }
+  t = omp_get_wtime()-ts;
+  ans = 0;
+  for(auto& x : pot) ans+=x;
+  std::cout << std::setprecision(16);
+  std::cout<<"N="<<ns<<", M="<<nt<<". manual VCL SIMD avx2 (256) fast rsqrt, ans: "<<ans<<"\n";
   std::cout << std::setprecision(3);
   std::cout<<"\t\t\t\ttime: "<<t<<" s      \t"<<ntest*ns*nt/t/1e9<<" Gpair/sec\n";
   
@@ -185,7 +288,7 @@ int main (void)
   t = omp_get_wtime()-ts;
   ans = 0;
   for(auto& x : pot) ans+=x;
-    std::cout << std::setprecision(15);
+    std::cout << std::setprecision(16);
   std::cout<<"N="<<ns<<", M="<<nt<<". target outer loop, ans: "<<ans<<"\n";
     std::cout << std::setprecision(3);
   std::cout<<"\t\t\t\ttime: "<<t<<" s      \t"<<ntest*ns*nt/t/1e9<<" Gpair/sec\n";
@@ -200,7 +303,7 @@ int main (void)
   t = omp_get_wtime()-ts;
   ans = 0;
   for(auto& x : pot) ans+=x;
-    std::cout << std::setprecision(15);
+    std::cout << std::setprecision(16);
   std::cout<<"N="<<ns<<", M="<<nt<<". source outer loop, ans: "<<ans<<"\n";
   std::cout << std::setprecision(3);
   std::cout<<"\t\t\t\ttime: "<<t<<" s      \t"<<ntest*ns*nt/t/1e9<<" Gpair/sec\n";


### PR DESCRIPTION
This PR add approximate rsqrt calculation in c++. By using Newton iterations in double precision, one can achieve significant  speed up compared to native simd sqrt function.