### PR TITLE
Improvements to Julia version of lap3dkernel

### DIFF
--- a/lap3dkernel/run_all_tests.sh
+++ b/lap3dkernel/run_all_tests.sh
@@ -18,9 +18,9 @@ echo FORTRAN:
 #(cd fortran; ifort lap3dpottest.f90 -qopenmp -fPIC -O3 -march=native -funroll-loops -mkl; ./a.out)
 
 
-echo JULIA:
+echo JULIA with $(nproc) processors:
 # note you'll need to import some Pkgs into your julia distro
-JULIA_NUM_THREADS=$(nproc) julia julia/lap3dkernel.jl
+JULIA_NUM_THREADS=$(nproc) julia --check-bounds=no -O3 julia/lap3dkernel.jl
 
 echo PYTHON:
 # assumes python is your v3 version w/ numba, eg via: source activate idp


### PR DESCRIPTION
- Implement a vectorized Julia version of the `lap3dkernel` function. It relies on the package `SIMD.jl` to perform "explicit" vectorization. On my machine, this brings the performance close to the one observed on the vectorized C++ code. 
- Make julia version work with single precision, and modify the script to print these benchmarks.